### PR TITLE
fix 332 presa in carico pec e mail attachmentUrl is empty

### DIFF
--- a/src/main/java/it/pagopa/pn/ec/commons/service/impl/AttachmentServiceImpl.java
+++ b/src/main/java/it/pagopa/pn/ec/commons/service/impl/AttachmentServiceImpl.java
@@ -6,6 +6,7 @@ import it.pagopa.pn.ec.commons.service.AttachmentService;
 import it.pagopa.pn.ec.rest.v1.dto.FileDownloadResponse;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 
@@ -30,6 +31,7 @@ public class AttachmentServiceImpl implements AttachmentService {
         }).flatMap(object -> {
             String attachmentUrl = (String) object;
             return uriBuilderCall.getFile(attachmentUrl.substring(ATTACHMENT_PREFIX.length()), xPagopaExtchCxId, metadataOnly);
-        });
+        })
+          .switchIfEmpty(Mono.just(new FileDownloadResponse()));
     }
 }


### PR DESCRIPTION
è possibile effettuare la presa in carico anche con una lista di attachment url vuota