### PR TITLE
Aruba retry strategy now set to 5-5 to circumvent fake exponential

### DIFF
--- a/src/main/resources/scaricamentoesitipec/aruba-call-retry-strategy.properties
+++ b/src/main/resources/scaricamentoesitipec/aruba-call-retry-strategy.properties
@@ -1,2 +1,2 @@
-aruba-call-retry-strategy.maxAttempts=${ArubaCallRetryStrategyMaxAttempts:4}
-aruba-call-retry-strategy.minBackoff=${ArubaCallRetryStrategyMinBackoff:3}
+aruba-call-retry-strategy.maxAttempts=${ArubaCallRetryStrategyMaxAttempts:5}
+aruba-call-retry-strategy.minBackoff=${ArubaCallRetryStrategyMinBackoff:5}


### PR DESCRIPTION
backoff strategy of reactor