### PR TITLE
PN-10631: Added new properties

### DIFF
--- a/scripts/aws/cfn/microservice-dev-cfg.json
+++ b/scripts/aws/cfn/microservice-dev-cfg.json
@@ -37,6 +37,8 @@
     "PnEcNamirialPoolSmtpMaxtotal": "",
     "PnEcNamirialPoolSmtpMaxidle": "",
     "PnEcNamirialPoolSmtpMinidle": "",
+    "PnEcNamirialServerMaxConnections": "32",
+    "PnEcNamirialServerPendingAcquireTimeout": "600",
     "CpuValue": "1024",
     "MemoryAmount": "4GB"
   }

--- a/scripts/aws/cfn/microservice.yml
+++ b/scripts/aws/cfn/microservice.yml
@@ -843,6 +843,13 @@ Parameters:
   PnEcNamirialPoolSmtpMinidle:
     Type: String
 
+  PnEcNamirialServerMaxConnections:
+    Type: String
+
+  PnEcNamirialServerPendingAcquireTimeout:
+    Type: Number
+    Description: Value in seconds
+
   CpuValue:
     Type: Number
     Default: 1024
@@ -947,6 +954,8 @@ Resources:
         ContainerEnvEntry73: !Sub 'PnEcNamirialPoolSmtpMaxtotal=${PnEcNamirialPoolSmtpMaxtotal}'
         ContainerEnvEntry74: !Sub 'PnEcNamirialPoolSmtpMaxidle=${PnEcNamirialPoolSmtpMaxidle}'
         ContainerEnvEntry75: !Sub 'PnEcNamirialPoolSmtpMinidle=${PnEcNamirialPoolSmtpMinidle}'
+        ContainerEnvEntry76: !Sub 'PnEcNamirialServerMaxConnections=${PnEcNamirialServerMaxConnections}'
+        ContainerEnvEntry77: !Sub 'PnEcNamirialServerPendingAcquireTimeout=${PnEcNamirialServerPendingAcquireTimeout}'
         ContainerSecret1: !Sub 'ConsolidatoreClientApiKey=arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:pn-EC-Secrets:ConsolidatoreClientApiKey:AWSCURRENT:'
         MicroServiceSecretPrefix: pn-EC-Secrets
         MappedPaths: '/external-channels/*,/external-channel/*,/consolidatore-ingress/*'

--- a/src/main/resources/namirial/namirial.properties
+++ b/src/main/resources/namirial/namirial.properties
@@ -17,3 +17,7 @@ namirial.pool.smtp.maxtotal=${PnEcNamirialPoolSmtpMaxtotal}
 namirial.pool.smtp.maxidle=${PnEcNamirialPoolSmtpMaxidle}
 
 namirial.pool.smtp.minidle=${PnEcNamirialPoolSmtpMinidle}
+
+namirial.server.max-connections=${PnEcNamirialServerMaxConnections}
+
+namirial.server.pending-acquire-timeout=${PnEcNamirialServerPendingAcquireTimeout}


### PR DESCRIPTION
namirial.server.max-connections  (default 32), namirial.server.pending-acquire-timeout (default 600)